### PR TITLE
Added ability to specify exchange properties. useful when publishing to an existing exchange.

### DIFF
--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -22,13 +22,24 @@ var AMQP = exports.AMQP = function (options) {
   this.port       = options.port       || 5672;
   this.vhost      = options.vhost      || '/';
   this.login      = options.login      || 'guest';
-  this.password   = options.password   || 'guest';
-  this.exchange   = options.exchange   || 'winston.log';
+  this.password   = options.password   || 'guest';  
   this.level      = options.level      || 'info';
   this.silent     = options.silent     || false;
   this.keepAlive  = options.keepAlive  || true;
   this.state      = 'unopened';
-  this.pending    = [];
+  this.pending    = [];  
+
+  this.exchange = (typeof options.exchange == 'object')
+    ? options.exchange
+    : { name: options.exchange };
+
+  if (!this.exchange.name) {
+    this.exchange.name = 'winston.log';
+  }
+  
+  if (!this.exchange.properties) {
+    this.exchange.properties = {};
+  }
 
   this.connection = amqp.createConnection({ 
     host: this.host,
@@ -145,7 +156,7 @@ AMQP.prototype.open = function (callback) {
   this.state = 'opening';
   // Wait for connection to become established.
   self.connection.on('ready', function () {
-    var exchange = self.connection.exchange(self.exchange, {});
+    var exchange = self.connection.exchange(self.exchange.name, self.exchange.properties);
     exchange.on('open', function () {
       console.log('Exchange \"' + exchange.name + '\" is open');
       flushPending(null, exchange);

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -68,7 +68,7 @@ var AMQP = exports.AMQP = function (options) {
     }
   });
 
-  var defaultTransformMessage = function(msg, meta) {
+  var defaultTransformMessage = function(level, msg, meta) {
     return { 'text': msg, 'meta': meta };
   };
 };

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -18,15 +18,15 @@ var AMQP = exports.AMQP = function (options) {
   options = options || {};
   
   this.name             = 'amqp';
-  this.host             = options.host       || 'localhost';
-  this.port             = options.port       || 5672;
-  this.vhost            = options.vhost      || '/';
-  this.login            = options.login      || 'guest';
-  this.password         = options.password   || 'guest';  
-  this.level            = options.level      || 'info';
-  this.silent           = options.silent     || false;
-  this.keepAlive        = options.keepAlive  || true;
-  this.transformMessage = options.transform  || defaultTransformMessage;
+  this.host             = options.host             || 'localhost';
+  this.port             = options.port             || 5672;
+  this.vhost            = options.vhost            || '/';
+  this.login            = options.login            || 'guest';
+  this.password         = options.password         || 'guest';  
+  this.level            = options.level            || 'info';
+  this.silent           = options.silent           || false;
+  this.keepAlive        = options.keepAlive        || true;
+  this.transformMessage = options.transformMessage || defaultTransformMessage;
   this.state            = 'unopened';
   this.pending          = [];    
 

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -16,6 +16,10 @@ var util = require('util'),
 //
 var AMQP = exports.AMQP = function (options) {
   options = options || {};
+
+  this.defaultTransformMessage = function(level, msg, meta) {
+    return { 'text': msg, 'meta': meta };
+  };
   
   this.name             = 'amqp';
   this.host             = options.host             || 'localhost';
@@ -26,7 +30,7 @@ var AMQP = exports.AMQP = function (options) {
   this.level            = options.level            || 'info';
   this.silent           = options.silent           || false;
   this.keepAlive        = options.keepAlive        || true;
-  this.transformMessage = options.transformMessage || defaultTransformMessage;
+  this.transformMessage = options.transformMessage || this.defaultTransformMessage;
   this.state            = 'unopened';
   this.pending          = [];    
 
@@ -66,11 +70,7 @@ var AMQP = exports.AMQP = function (options) {
         }, 10000);
         break;
     }
-  });
-
-  var defaultTransformMessage = function(level, msg, meta) {
-    return { 'text': msg, 'meta': meta };
-  };
+  });  
 };
 
 //

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -17,17 +17,18 @@ var util = require('util'),
 var AMQP = exports.AMQP = function (options) {
   options = options || {};
   
-  this.name       = 'amqp';
-  this.host       = options.host       || 'localhost';
-  this.port       = options.port       || 5672;
-  this.vhost      = options.vhost      || '/';
-  this.login      = options.login      || 'guest';
-  this.password   = options.password   || 'guest';  
-  this.level      = options.level      || 'info';
-  this.silent     = options.silent     || false;
-  this.keepAlive  = options.keepAlive  || true;
-  this.state      = 'unopened';
-  this.pending    = [];  
+  this.name             = 'amqp';
+  this.host             = options.host       || 'localhost';
+  this.port             = options.port       || 5672;
+  this.vhost            = options.vhost      || '/';
+  this.login            = options.login      || 'guest';
+  this.password         = options.password   || 'guest';  
+  this.level            = options.level      || 'info';
+  this.silent           = options.silent     || false;
+  this.keepAlive        = options.keepAlive  || true;
+  this.transformMessage = options.transform  || defaultTransformMessage;
+  this.state            = 'unopened';
+  this.pending          = [];    
 
   this.exchange = (typeof options.exchange == 'object')
     ? options.exchange
@@ -66,6 +67,10 @@ var AMQP = exports.AMQP = function (options) {
         break;
     }
   });
+
+  var defaultTransformMessage = function(msg, meta) {
+    return { 'text': msg, 'meta': meta };
+  };
 };
 
 //
@@ -98,7 +103,7 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
     if (err) {
       self.emit('error', err);
     }
-    self._exchange.publish(level, {'text': msg, 'meta': meta});
+    self._exchange.publish(level, self.transformMessage(level, msg, meta));
     self.emit('logged');
     callback(null, true);
   });

--- a/test/winston-amqp-test.js
+++ b/test/winston-amqp-test.js
@@ -13,25 +13,82 @@ var path = require('path'),
     helpers = require('winston/test/helpers'),
     AMQP = require('../lib/winston-amqp').AMQP;
 
-function assertAMQP(transport) {
-  assert.instanceOf(transport, AMQP);
-  assert.isFunction(transport.log);
-};
-
-var config = helpers.loadConfig(__dirname),
-    transport = new (AMQP)(config.transports.amqp);
+var config = helpers.loadConfig(__dirname);
 
 vows.describe('winston-amqp').addBatch({
  "An instance of the AMQP Transport": {
-   "should have the proper methods defined": function () {
-     assertAMQP(transport);
-   },
-   "the log() method": helpers.testNpmLevels(transport, "should log messages to AMQP server", function (ign, err, logged) {
-     assert.isTrue(!err);
-     assert.isTrue(logged);
-   })
- }
+    topic: function() {
+      return new (AMQP)(config.transports.amqp);
+    },
+    "is an instance of the AMQP transport": function(topic) {
+      assert.instanceOf(topic, AMQP);
+    },
+    "has a log function defined": function (topic) {      
+      assert.isFunction(topic.log);
+    }
+    // "the log() method": helpers.testNpmLevels(transport, "should log messages to AMQP server", function (ign, err, logged) {
+    //   assert.isTrue(!err);
+    //   assert.isTrue(logged);
+    // })
+  },
+  "An AMQP Transport instance with a custom exchange definition": {
+    topic: function() {
+      return new (AMQP)({
+        exchange: {
+          name: "winston.log",
+          properties: {
+            durable: true,
+            type: "topic"
+          }
+        }
+      });
+    },
+    "properly sets the exchange name": function(topic) {
+      assert.equal(topic.exchange.name, "winston.log");
+    },
+    "properly sets the exchange properties": function(topic) {
+      assert.deepEqual(topic.exchange.properties, {
+        durable: true,
+        type: "topic"
+      });
+    }
+  },
+  "An AMQP Transport instance with no custom transform message function specified": {
+    topic: function() {
+      return new (AMQP)();
+    },
+    "uses the default message transform function": function(topic) {
+      var level = "info"
+        , msg = "my message"
+        , meta = { propertyName: "propertyValue" };
+
+      var actualTransformedMessage = topic.transformMessage(level, msg, meta)
+        , expectedTransformedMessage = topic.defaultTransformMessage(level, msg, meta);
+
+      assert.deepEqual(actualTransformedMessage, expectedTransformedMessage);
+    }
+  },
+  "An AMQP Transport instance with a custom transform message function specified": {
+    topic: function() {
+      return new (AMQP)({
+        transformMessage: function(level, msg, meta) {
+          return level + "::" + msg + "::" + JSON.stringify(meta);
+        }
+      });
+    },
+    "uses the custom transform message function": function(topic) {
+      var level = "info"
+        , msg = "my message"
+        , meta = { propertyName: "propertyValue" };
+
+      var actualTransformedMessage = topic.transformMessage(level, msg, meta)
+        , expectedTransformedMessage = "info::my message::{\"propertyName\":\"propertyValue\"}";
+
+      assert.equal(actualTransformedMessage, expectedTransformedMessage);
+    }
+  }
 }).export(module);
+
 /*.addBatch({
   "An instance of the AMQP Transport": {
     "when the timeout has fired": {


### PR DESCRIPTION
I am using this library to publish messages to an existing exchange, so I need to be able to specify the properties of that exchange otherwise the AMQP module will attempt to create a new exchange with different properties and fail.
