### PR TITLE
Switched to Winston 0.7.x and reuse the object once created

### DIFF
--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -9,24 +9,24 @@
 var util = require('util'),
     amqp = require('amqp'),
     winston = require('winston');
-    
+
 //
 // ### function AMQP (options)
 // Constructor for the AMQP transport object.
 //
-var AMQP = exports.AMQP = function (options) {
+var AMQP = function (options) {
   options = options || {};
 
   this.defaultTransformMessage = function(level, msg, meta) {
     return { 'text': msg, 'meta': meta };
   };
-  
+
   this.name             = 'amqp';
   this.host             = options.host             || 'localhost';
   this.port             = options.port             || 5672;
   this.vhost            = options.vhost            || '/';
   this.login            = options.login            || 'guest';
-  this.password         = options.password         || 'guest';  
+  this.password         = options.password         || 'guest';
   this.level            = options.level            || 'info';
   this.silent           = options.silent           || false;
   this.keepAlive        = options.keepAlive        || true;
@@ -42,12 +42,12 @@ var AMQP = exports.AMQP = function (options) {
   if (!this.exchange.name) {
     this.exchange.name = 'winston.log';
   }
-  
+
   if (!this.exchange.properties) {
     this.exchange.properties = {};
   }
 
-  this.connection = amqp.createConnection({ 
+  this.connection = amqp.createConnection({
     host: this.host,
     port: this.port,
     vhost: this.vhost,
@@ -71,8 +71,16 @@ var AMQP = exports.AMQP = function (options) {
         }, 10000);
         break;
     }
-  });  
+  });
 };
+
+var _factory = exports.AMQP = function (options) {
+  if ("undefined" == typeof this.factored) {
+     this.factored = new AMQP(options);
+  }
+
+  return this.factored;
+}
 
 //
 // Inherit from `winston.Transport`.
@@ -80,10 +88,10 @@ var AMQP = exports.AMQP = function (options) {
 util.inherits(AMQP, winston.Transport);
 
 //
-// Define a getter so that `winston.transports.AMQP` 
+// Define a getter so that `winston.transports.AMQP`
 // is available and thus backwards compatible.
 //
-winston.transports.AMQP = AMQP;
+winston.transports.AMQP = _factory;
 
 //
 // ### function log (level, msg, [meta], callback)
@@ -99,11 +107,11 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
-  
+
   if (this.timestamp === true) {
       meta.timestamp = new Date().toISOString();
   }
-    
+
   this.open(function (err) {
     if (err) {
       self.emit('error', err);
@@ -122,14 +130,14 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
 //
 AMQP.prototype.open = function (callback) {
   var self = this;
-  
+
   if (this.state === 'opening' || this.state === 'unopened') {
     //
     // While opening our AMQP connection, append any callback
-    // to a list that is managed by this instance. 
+    // to a list that is managed by this instance.
     //
     this.pending.push(callback);
-    
+
     if (this.state === 'opening') {
       return;
     }
@@ -140,11 +148,11 @@ AMQP.prototype.open = function (callback) {
   else if (this.state === 'error') {
     return callback(err);
   }
-  
+
   function flushPending (err, exchange) {
     self._exchange = exchange;
     self.state = 'opened';
-    
+
     //
     // Iterate over all callbacks that have accumulated during
     // the creation of the TCP socket.
@@ -152,30 +160,30 @@ AMQP.prototype.open = function (callback) {
     for (var i = 0; i < self.pending.length; i++) {
       self.pending[i]();
     }
-    
+
     // Quickly truncate the Array (this is more performant).
     self.pending.length = 0;
   }
-  
+
   function onError (err) {
     self.state = 'error';
     self.error = err;
     flushPending(err, false);
   }
-  
+
   this.state = 'opening';
   // Wait for connection to become established.
   self.connection.on('ready', function () {
-    var exchange = self.connection.exchange(self.exchange.name, self.exchange.properties);
+    var exchange = self._exchange || self.connection.exchange(self.exchange.name, self.exchange.properties);
     exchange.on('open', function () {
       console.log('Exchange \"' + exchange.name + '\" is open');
       flushPending(null, exchange);
     });
   });
-  
+
   //
   // Set a timeout to end the amqp connection unless `this.keepAlive`
-  // has been set to true in which case it is the responsibility of the 
+  // has been set to true in which case it is the responsibility of the
   // programmer to close the underlying connection.
   //
   if (!(this.keepAlive === true)) {

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -32,7 +32,8 @@ var AMQP = exports.AMQP = function (options) {
   this.keepAlive        = options.keepAlive        || true;
   this.transformMessage = options.transformMessage || this.defaultTransformMessage;
   this.state            = 'unopened';
-  this.pending          = [];    
+  this.pending          = [];
+  this.timestamp  = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
 
   this.exchange = (typeof options.exchange == 'object')
     ? options.exchange
@@ -97,6 +98,10 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
 
   if (this.silent) {
     return callback(null, true);
+  }
+  
+  if (this.timestamp === true) {
+      meta.timestamp = new Date().toISOString();
   }
     
   this.open(function (err) {

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -176,7 +176,7 @@ AMQP.prototype.open = function (callback) {
   self.connection.on('ready', function () {
     var exchange = self._exchange || self.connection.exchange(self.exchange.name, self.exchange.properties);
     exchange.on('open', function () {
-      console.log('Exchange \"' + exchange.name + '\" is open');
+      //console.log('Exchange \"' + exchange.name + '\" is open');
       flushPending(null, exchange);
     });
   });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": ["logging", "sysadmin", "tools", "winston", "amqp", "rabbitmq"],
   "dependencies": {
     "amqp": "0.1.x",
-    "winston": "0.5.x"
+    "winston": "0.7.x"
   },
   "devDependencies": {
     "vows": "0.5.x",


### PR DESCRIPTION
Updated winston version in the requirements to 0.7.x because (at least for me) it fails to load it if it uses the 0.5.x version.
I realised that winston will recreate the transport object on each log call so I just implemented a kind of refactoring to avoid this. Also I modified it to reuse the exchange object. Every time self.connection.exchange is called a new channel is opened (see https://github.com/postwait/node-amqp/issues/247#issuecomment-25678090) which can lead to channel overflow.
Also I added an option to add a timestamp to the meta data.
