### PR TITLE
Accept existing node-amqp connection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 *.stderr
 *.stdout
+atlassian-ide-plugin.xml
+.idea

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The AMQP transport takes the following options:
 * __vhost:__ virtual host entry for the RabbitMQ server, defaults to '/'
 * __login:__ login for the RabbitMQ server, defaults to 'guest'
 * __password:__ password for the RabbitMQ server, defaults to 'guest'
+* __connection:__ optionally you may provide an existing AMQP connection instead of the credentials.
 
 *Metadata:* Logged as part of the message body with key 'meta' (see examples/subscribe.js).
 

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -8,8 +8,11 @@
 
 var util = require('util'),
     amqp = require('amqp'),
-    winston = require('winston');
-    
+    winston = require('winston'),
+    _ = require('lodash');
+
+var createConnectionFieldNames = ['host', 'port', 'vhost', 'login', 'password'];
+
 //
 // ### function AMQP (options)
 // Constructor for the AMQP transport object.
@@ -20,39 +23,39 @@ var AMQP = exports.AMQP = function (options) {
   this.defaultTransformMessage = function(level, msg, meta) {
     return { 'text': msg, 'meta': meta };
   };
-  
+
+  if (options.connection) {
+    _.assign(options,
+        _.pick(options.connection.options, createConnectionFieldNames));
+  }
+
   this.name             = 'amqp';
   this.host             = options.host             || 'localhost';
   this.port             = options.port             || 5672;
   this.vhost            = options.vhost            || '/';
   this.login            = options.login            || 'guest';
-  this.password         = options.password         || 'guest';  
+  this.password         = options.password         || 'guest';
   this.level            = options.level            || 'info';
   this.silent           = options.silent           || false;
   this.keepAlive        = options.keepAlive        || true;
   this.transformMessage = options.transformMessage || this.defaultTransformMessage;
   this.state            = 'unopened';
-  this.pending          = [];    
+
+  this.pending          = [];
+
+  this.connection = options.connection || amqp.createConnection(_.pick(this, createConnectionFieldNames));
 
   this.exchange = (typeof options.exchange == 'object')
     ? options.exchange
     : { name: options.exchange };
-
   if (!this.exchange.name) {
     this.exchange.name = 'winston.log';
   }
-  
+
   if (!this.exchange.properties) {
     this.exchange.properties = {};
   }
 
-  this.connection = amqp.createConnection({ 
-    host: this.host,
-    port: this.port,
-    vhost: this.vhost,
-    login: this.login,
-    password: this.password
-  });
 
   this.connection.on('error', function(err){
     var self = this;
@@ -160,14 +163,21 @@ AMQP.prototype.open = function (callback) {
   
   this.state = 'opening';
   // Wait for connection to become established.
-  self.connection.on('ready', function () {
+
+  function onReady() {
     var exchange = self.connection.exchange(self.exchange.name, self.exchange.properties);
     exchange.on('open', function () {
       console.log('Exchange \"' + exchange.name + '\" is open');
       flushPending(null, exchange);
     });
-  });
-  
+  }
+
+  if (self.connection.readyEmitted) {
+    onReady();
+  } else {
+    self.connection.on('ready', onReady);
+  }
+
   //
   // Set a timeout to end the amqp connection unless `this.keepAlive`
   // has been set to true in which case it is the responsibility of the 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,19 @@
   "author": "Krispin Schulz <krispinone@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/kr1sp1n/winston-amqp.git" 
+    "url": "http://github.com/kr1sp1n/winston-amqp.git"
   },
-  "keywords": ["logging", "sysadmin", "tools", "winston", "amqp", "rabbitmq"],
+  "keywords": [
+    "logging",
+    "sysadmin",
+    "tools",
+    "winston",
+    "amqp",
+    "rabbitmq"
+  ],
   "dependencies": {
     "amqp": "0.1.x",
+    "lodash": "^2.4.1",
     "winston": "0.5.x"
   },
   "devDependencies": {
@@ -17,6 +25,10 @@
     "colors": "0.5.x"
   },
   "main": "./lib/winston-amqp",
-  "scripts": { "test": "vows --spec" },
-  "engines": { "node": ">= 0.4.0" }
+  "scripts": {
+    "test": "vows --spec"
+  },
+  "engines": {
+    "node": ">= 0.4.0"
+  }
 }


### PR DESCRIPTION
Allow winston-amqp to accept an existing connection to avoid separate connections to be instantiated with each winston-amqp instance.
