### PR TITLE
SSL & Connection-ready fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Inspired by [winston-mongodb][1].
 
 The AMQP transport takes the following options:
 
-* __level:__ Level of messages that this transport should log. 
+* __level:__ Level of messages that this transport should log.
 * __silent:__ Boolean flag indicating whether to suppress output.
 * __exchange__: The name of the exchange you want to push log messages in, defaults to 'winston.log'.
 * __host:__ The host running RabbitMQ, defaults to localhost.
@@ -34,6 +34,8 @@ The AMQP transport takes the following options:
 * __vhost:__ virtual host entry for the RabbitMQ server, defaults to '/'
 * __login:__ login for the RabbitMQ server, defaults to 'guest'
 * __password:__ password for the RabbitMQ server, defaults to 'guest'
+* __authMechanism:__ authMechanism to use with RabbitMQ server, defaults to 'AMQPLAIN'
+* __ssl:__ ssl connect via SSL to RabbitMQ server, defaults to '{ enabled : false }'. For options check: https://github.com/postwait/node-amqp
 
 *Metadata:* Logged as part of the message body with key 'meta' (see examples/subscribe.js).
 

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -9,7 +9,7 @@
 var util = require('util'),
     amqp = require('amqp'),
     winston = require('winston');
-    
+
 //
 // ### function AMQP (options)
 // Constructor for the AMQP transport object.
@@ -20,19 +20,21 @@ var AMQP = exports.AMQP = function (options) {
   this.defaultTransformMessage = function(level, msg, meta) {
     return { 'text': msg, 'meta': meta };
   };
-  
+
   this.name             = 'amqp';
   this.host             = options.host             || 'localhost';
   this.port             = options.port             || 5672;
   this.vhost            = options.vhost            || '/';
   this.login            = options.login            || 'guest';
-  this.password         = options.password         || 'guest';  
+  this.password         = options.password         || 'guest';
   this.level            = options.level            || 'info';
   this.silent           = options.silent           || false;
   this.keepAlive        = options.keepAlive        || true;
+  this.authMechanism    = options.authMechanism    || 'AMQPLAIN';
+  this.ssl              = options.ssl              || { enabled : false };
   this.transformMessage = options.transformMessage || this.defaultTransformMessage;
   this.state            = 'unopened';
-  this.pending          = [];    
+  this.pending          = [];
 
   this.exchange = (typeof options.exchange == 'object')
     ? options.exchange
@@ -41,17 +43,19 @@ var AMQP = exports.AMQP = function (options) {
   if (!this.exchange.name) {
     this.exchange.name = 'winston.log';
   }
-  
+
   if (!this.exchange.properties) {
     this.exchange.properties = {};
   }
 
-  this.connection = amqp.createConnection({ 
+  this.connection = amqp.createConnection({
     host: this.host,
     port: this.port,
     vhost: this.vhost,
     login: this.login,
-    password: this.password
+    password: this.password,
+    authMechanism: this.authMechanism,
+    ssl: this.ssl
   });
 
   this.connection.on('error', function(err){
@@ -70,7 +74,7 @@ var AMQP = exports.AMQP = function (options) {
         }, 10000);
         break;
     }
-  });  
+  });
 };
 
 //
@@ -79,7 +83,7 @@ var AMQP = exports.AMQP = function (options) {
 util.inherits(AMQP, winston.Transport);
 
 //
-// Define a getter so that `winston.transports.AMQP` 
+// Define a getter so that `winston.transports.AMQP`
 // is available and thus backwards compatible.
 //
 winston.transports.AMQP = AMQP;
@@ -98,7 +102,7 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
-    
+
   this.open(function (err) {
     if (err) {
       self.emit('error', err);
@@ -117,14 +121,14 @@ AMQP.prototype.log = function (level, msg, meta, callback) {
 //
 AMQP.prototype.open = function (callback) {
   var self = this;
-  
+
   if (this.state === 'opening' || this.state === 'unopened') {
     //
     // While opening our AMQP connection, append any callback
-    // to a list that is managed by this instance. 
+    // to a list that is managed by this instance.
     //
     this.pending.push(callback);
-    
+
     if (this.state === 'opening') {
       return;
     }
@@ -135,11 +139,11 @@ AMQP.prototype.open = function (callback) {
   else if (this.state === 'error') {
     return callback(err);
   }
-  
+
   function flushPending (err, exchange) {
     self._exchange = exchange;
     self.state = 'opened';
-    
+
     //
     // Iterate over all callbacks that have accumulated during
     // the creation of the TCP socket.
@@ -147,17 +151,17 @@ AMQP.prototype.open = function (callback) {
     for (var i = 0; i < self.pending.length; i++) {
       self.pending[i]();
     }
-    
+
     // Quickly truncate the Array (this is more performant).
     self.pending.length = 0;
   }
-  
+
   function onError (err) {
     self.state = 'error';
     self.error = err;
     flushPending(err, false);
   }
-  
+
   this.state = 'opening';
   // Wait for connection to become established.
   self.connection.on('ready', function () {
@@ -167,10 +171,10 @@ AMQP.prototype.open = function (callback) {
       flushPending(null, exchange);
     });
   });
-  
+
   //
   // Set a timeout to end the amqp connection unless `this.keepAlive`
-  // has been set to true in which case it is the responsibility of the 
+  // has been set to true in which case it is the responsibility of the
   // programmer to close the underlying connection.
   //
   if (!(this.keepAlive === true)) {

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -10,6 +10,8 @@ var util = require('util'),
     amqp = require('amqp'),
     winston = require('winston');
 
+var is_ready = false;
+
 //
 // ### function AMQP (options)
 // Constructor for the AMQP transport object.
@@ -56,6 +58,10 @@ var AMQP = exports.AMQP = function (options) {
     password: this.password,
     authMechanism: this.authMechanism,
     ssl: this.ssl
+  });
+
+  this.connection.on('ready', function() {
+    is_ready = true;
   });
 
   this.connection.on('error', function(err){
@@ -164,13 +170,19 @@ AMQP.prototype.open = function (callback) {
 
   this.state = 'opening';
   // Wait for connection to become established.
-  self.connection.on('ready', function () {
+  function onReady() {
     var exchange = self.connection.exchange(self.exchange.name, self.exchange.properties);
     exchange.on('open', function () {
       console.log('Exchange \"' + exchange.name + '\" is open');
       flushPending(null, exchange);
     });
-  });
+  }
+
+  if(is_ready) {
+    onReady();
+  } else {
+    self.connection.on('ready', onReady);
+  }
 
   //
   // Set a timeout to end the amqp connection unless `this.keepAlive`

--- a/lib/winston-amqp.js
+++ b/lib/winston-amqp.js
@@ -33,6 +33,7 @@ var AMQP = exports.AMQP = function (options) {
   this.silent           = options.silent           || false;
   this.keepAlive        = options.keepAlive        || true;
   this.authMechanism    = options.authMechanism    || 'AMQPLAIN';
+  this.heartbeat        = options.heartbeat        || 60;
   this.ssl              = options.ssl              || { enabled : false };
   this.transformMessage = options.transformMessage || this.defaultTransformMessage;
   this.state            = 'unopened';
@@ -57,6 +58,7 @@ var AMQP = exports.AMQP = function (options) {
     login: this.login,
     password: this.password,
     authMechanism: this.authMechanism,
+    heartbeat: this.heartbeat,
     ssl: this.ssl
   });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-amqp",
   "description": "An AMQP transport for winston",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": "Krispin Schulz <krispinone@gmail.com>",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "amqp", "rabbitmq"],
   "dependencies": {
-    "amqp": "0.1.x",
+    "amqp": "~0.2.4",
     "winston": "~1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "author": "Krispin Schulz <krispinone@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/kr1sp1n/winston-amqp.git" 
+    "url": "http://github.com/kr1sp1n/winston-amqp.git"
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "amqp", "rabbitmq"],
   "dependencies": {
     "amqp": "0.1.x",
-    "winston": "0.5.x"
+    "winston": "~1.0.0"
   },
   "devDependencies": {
     "vows": "0.5.x",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": ["logging", "sysadmin", "tools", "winston", "amqp", "rabbitmq"],
   "dependencies": {
     "amqp": "~0.2.4",
-    "winston": "~1.0.0"
+    "winston": "~2.2.0"
   },
   "devDependencies": {
     "vows": "0.5.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "winston-amqp",
+  "name": "winston-amqp-fishtemp",
   "description": "An AMQP transport for winston",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Krispin Schulz <krispinone@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added SSL support and more important apply fix from:
https://github.com/TaDaweb/winston-amqp/commit/e0f9bf6202ad6de6fcd76a0492e14870191cf89b

Without the above fix it only sends logs to the queue when the first log happens directly after the node-app got started. If there is a lot of time between start and first log-message (like 2 seconds) the log never gets send.
